### PR TITLE
Update subscription labels and expand community page

### DIFF
--- a/src/components/blocks/pricing/MasterPricing.astro
+++ b/src/components/blocks/pricing/MasterPricing.astro
@@ -29,7 +29,7 @@ const plans: Plan[] = [
   {
     type: 'basic',
     header: {
-      title: 'Light',
+      title: 'Start',
       subtitle: 'Идеально, чтобы попробовать',
       currency: '₽',
       price: '500',
@@ -50,7 +50,7 @@ const plans: Plan[] = [
   {
     type: 'featured',
     header: {
-      title: 'PRO',
+      title: 'Light',
       subtitle: 'если предпочитаешь продавать на живой консультации',
       currency: '₽',
       price: '1700',
@@ -74,7 +74,7 @@ const plans: Plan[] = [
   {
     type: 'basic',
     header: {
-      title: 'PRO',
+      title: 'Pro',
       subtitle: 'для тех, кто хочет ленивых продаж через ссылку в профиле',
       currency: '₽',
       price: '6000',

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -5,7 +5,9 @@ import Layout from '../layouts/Layout.astro'
 // - UI
 import CommunityIntro from '../components/blocks/community/CommunityIntro.astro'
 import CommunityCards from '../components/blocks/community/CommunityCards.astro'
-import FAQ from '../components/blocks/FAQ/Basic.astro'
+import FaqSticky from '../components/blocks/FAQ/FaqSticky.astro'
+import FAQBasic from '../components/blocks/FAQ/Basic.astro'
+import TextImage from '../components/blocks/basic/TextImage.astro'
 import Testimonial from '../components/blocks/testimonials/BasicDark.astro'
 import Feature from '../components/blocks/features/FeatureList.astro'
 import CTA from '../components/blocks/CTA/BasicDark.astro'
@@ -21,6 +23,11 @@ const SEO = {
 // No default header; custom community intro instead
 // - Testimonial data
 import testimonialBackground from '../assets/testimonial-bg-02.webp'
+// - FAQ data
+import faqData from '../data/json-files/faqData.json'
+const faqPricing = faqData.filter((faq) => faq.category === 'pricing')
+// - Image for text block
+import faqImage1 from '../assets/faq/faq-01.png'
 const testimonialData = {
 	blockquote:
 		'Забери рынок до того, как это сделают другие: первый White Label бот для наращивания может стать твоим личным золотым рудником.',
@@ -32,6 +39,15 @@ const testimonialData = {
 <Layout title={SEO.title} description={SEO.description}>
     <CommunityIntro />
     <CommunityCards />
+    <TextImage
+      title="Why Foxi’s Pricing Plans Offer Great Value"
+      text="At Foxi, we believe in providing exceptional value at every price point. Our pricing plans are designed to cater to a variety of needs, from individuals and small teams to large enterprises. Each plan includes access to our powerful features, seamless integrations, and top-notch customer support. "
+      image={faqImage1}
+      mobileImage={faqImage1}
+      imagePosition="left"
+      offsetImage
+      classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"
+    />
     <Testimonial
       bg={testimonialBackground}
       bgPosition="left"
@@ -39,7 +55,12 @@ const testimonialData = {
       figcaption={testimonialData.figcaption}
       cite={testimonialData.cite}
     />
-    <FAQ classes="bg-slate-50 dark:bg-neutral-900/40" />
+    <FaqSticky
+      title="Understanding Our Pricing Plans"
+      text="Get all the details on Foxi’s pricing plans. Learn about the costs, discounts, and subscription options to find the best plan that fits your needs and budget."
+      data={faqPricing}
+      classes="bg-slate-50 dark:bg-neutral-900/40"
+    />
     <Feature />
-    <FAQ classes="bg-slate-50 dark:bg-neutral-900/40" />
+    <FAQBasic classes="bg-slate-50 dark:bg-neutral-900/40" />
 </Layout>


### PR DESCRIPTION
## Summary
- Rename Master subscription tiers to Start, Light, and Pro
- Add image-text and sticky FAQ sections to community pricing page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2df4c318832abfc1911f1baf8742