### PR TITLE
Fix pricing list HTML rendering and carousel tap navigation

### DIFF
--- a/src/components/blocks/hero/HeroSwiper.astro
+++ b/src/components/blocks/hero/HeroSwiper.astro
@@ -84,10 +84,20 @@ const { screenshots = [], eager = false } = Astro.props as {
       el.speed = 500
       // focusable for keyboard
       el.tabIndex = 0
-      // click anywhere except interactive child -> next by one
-      el.addEventListener('click', (e) => {
+      // tap/click anywhere except interactive child -> next by one
+      let pointerDown = false
+      const isInteractive = (t: HTMLElement | null) =>
+        t && t.closest?.('a,button,[role="button"],input,textarea,select')
+      el.addEventListener('pointerdown', (e) => {
         const t = e.target as HTMLElement | null
-        if (t && t.closest?.('a,button,[role="button"],input,textarea,select')) return
+        if (isInteractive(t)) return
+        pointerDown = true
+      })
+      el.addEventListener('pointerup', (e) => {
+        const t = e.target as HTMLElement | null
+        if (isInteractive(t)) return
+        if (!pointerDown) return
+        pointerDown = false
         el.swiper?.slideNext()
       })
       el.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -98,12 +108,6 @@ const { screenshots = [], eager = false } = Astro.props as {
           e.preventDefault()
           el.swiper?.slidePrev()
         }
-      })
-      // extra: ensure tap/pointer triggers next as well
-      el.addEventListener('pointerup', (e) => {
-        const t = e.target as HTMLElement | null
-        if (t && t.closest?.('a,button,[role="button"],input,textarea,select')) return
-        el.swiper?.slideNext()
       })
     }
   }

--- a/src/components/ui/List.astro
+++ b/src/components/ui/List.astro
@@ -31,12 +31,13 @@ const { type = 'basic', listColor = 'primary', listItems, classes } = Astro.prop
 	]}
 >
 	{
-		listItems.map((item) => (
-			<li>
-				{type === 'checklist' && <Icon name="check-circle" />} {item.listItem}
-			</li>
-		))
-	}
+                listItems.map((item) => (
+                        <li>
+                                {type === 'checklist' && <Icon name="check-circle" />}
+                                <span set:html={item.listItem}></span>
+                        </li>
+                ))
+        }
 </ul>
 
 <style>


### PR DESCRIPTION
## Summary
- render list item content as HTML so `<strong>` works
- ensure swiper waits for pointer down and advances slides on tap

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb51950818832a87b867c7d253e34d