### PR TITLE
feat: add community toast and image

### DIFF
--- a/src/components/ui/Toast.astro
+++ b/src/components/ui/Toast.astro
@@ -10,10 +10,10 @@
 <div id="foxi-toast" class="toast" style="display: none">
 	<div class="toast__container" role="status">
 		<!-- Heading with close button -->
-		<div class="toast__heading">
-			<!-- Headline -->
-			<h3 class="toast__headline">Ready to go bigger?</h3>
-			<!-- Close button -->
+                <div class="toast__heading">
+                        <!-- Headline -->
+                        <h3 class="toast__headline">Это демо-витрина.</h3>
+                        <!-- Close button -->
 			<button aria-label="Close" class="toast__close-button" id="foxi-toast-close">
 				<span class="toast__close-button-icon">
 					<svg
@@ -30,12 +30,12 @@
 			</button>
 		</div>
 		<!-- Body -->
-		<div class="toast__body">
-			<p>
-				Unlock <a href="https://astro.build/themes/details/foxi-pro/" target="_blank">Foxi Pro</a> —
-				CMS, multilingual, animations, and advanced UI.
-			</p>
-		</div>
+                <div class="toast__body">
+                        <p>
+                                Платформа продается, готова к адаптации под ваш бренд.
+                                <a href="/create-community">Платформа продается</a>
+                        </p>
+                </div>
 		<!-- Actions -->
 		<div class="toast__actions"></div>
 	</div>

--- a/src/pages/create-community.astro
+++ b/src/pages/create-community.astro
@@ -1,0 +1,13 @@
+---
+import Layout from '../layouts/Layout.astro'
+const SEO = {
+  title: 'Создать сообщество',
+  description: 'Страница для создания собственного сообщества.'
+}
+---
+
+<Layout title={SEO.title} description={SEO.description}>
+  <section class="py-32">
+    <h1 class="text-center text-3xl">Создать сообщество</h1>
+  </section>
+</Layout>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -27,7 +27,7 @@ import testimonialBackground from '../assets/testimonial-bg-02.webp'
 import faqData from '../data/json-files/faqData.json'
 const faqPricing = faqData.filter((faq) => faq.category === 'pricing')
 // - Image for text block
-import faqImage1 from '../assets/faq/faq-01.png'
+const easyClientImage = { src: '/easy_client.png' }
 const testimonialData = {
 	blockquote:
 		'Забери рынок до того, как это сделают другие: первый White Label бот для наращивания может стать твоим личным золотым рудником.',
@@ -42,8 +42,8 @@ const testimonialData = {
     <TextImage
       title="Why Foxi’s Pricing Plans Offer Great Value"
       text="At Foxi, we believe in providing exceptional value at every price point. Our pricing plans are designed to cater to a variety of needs, from individuals and small teams to large enterprises. Each plan includes access to our powerful features, seamless integrations, and top-notch customer support. "
-      image={faqImage1}
-      mobileImage={faqImage1}
+      image={easyClientImage}
+      mobileImage={easyClientImage}
       imagePosition="left"
       offsetImage
       classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"


### PR DESCRIPTION
## Summary
- update toast content to point to create community page
- show easy_client image on community page text block
- add placeholder create community page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb5cb364e0832a98ecf55012c5ddf7