### PR TITLE
feat: update footer and white label content

### DIFF
--- a/src/components/blocks/community/CommunityIntro.astro
+++ b/src/components/blocks/community/CommunityIntro.astro
@@ -21,7 +21,10 @@ const avatars = [
     <Col span="2" />
     <Col span="8" align="center">
       <ChipNotification radius="rounded-full" classes="mb-6">
-        <strong>Сеть мастеров</strong>  под твоим брендом
+        <span class="flex flex-col sm:flex-row sm:items-center">
+          <strong>Сеть мастеров</strong>
+          <span class="sm:ml-1">под твоим брендом</span>
+        </span>
         <AvatarGroup avatars={avatars} radius="rounded-full" slot="button" />
       </ChipNotification>
       <h1 class="text-pretty">

--- a/src/components/blocks/features/WhiteLabelIncludes.astro
+++ b/src/components/blocks/features/WhiteLabelIncludes.astro
@@ -1,0 +1,77 @@
+---
+// White Label Features List without heading
+// ------------
+// Description: Displays White Label platform benefits as feature cards.
+
+import Section from '../../ui/Section.astro'
+import Row from '../../ui/Row.astro'
+import Col from '../../ui/Col.astro'
+import Feature from '../../ui/Feature.astro'
+
+const features = [
+  {
+    title: 'White-Label решение',
+    icon: 'paint-brush',
+    text: 'усиливает твой бренд, а не чужой.'
+  },
+  {
+    title: 'База мастеров и CRM-ядро',
+    icon: 'circle-stack',
+    text: 'твоя собственная экосистема.'
+  },
+  {
+    title: 'Маркетинговые возможности',
+    icon: 'squares-plus',
+    text: 'рассылки, рекламные интеграции и монетизация внутри бота.'
+  },
+  {
+    title: 'Дополнительный доход',
+    icon: 'shopping-cart',
+    text: 'продажа волос, косметики, курсов, колористики.'
+  },
+  {
+    title: 'Доход от генераций',
+    icon: 'document-chart-bar',
+    text: 'фото и видео демок: 75 % с генераций — ваши. Мы берем только 25% за использование сервера и нейросетей.'
+  },
+  {
+    title: 'Прозрачная модель',
+    icon: 'scale',
+    text: 'каждый мастер платит за использование, а владелец зарабатывает на обороте.'
+  },
+  {
+    title: 'Единый вход для индустрии',
+    icon: 'user-group',
+    text: 'платформа превращается в must-have для мастеров:',
+    bullets: [
+      'покупка волос, кератина и материалов,',
+      'продажа собственных услуг,',
+      'повышение квалификации и курсы,',
+      'сообщество и партнёрские предложения.'
+    ]
+  }
+]
+---
+<Section>
+  <Row>
+    {
+      features.map((feature) => (
+        <Col span="4">
+          <Feature title={feature.title} icon={feature.icon} align="left" classes="mb-12">
+            {feature.text}
+            {
+              feature.bullets && (
+                <ul class="mt-2 list-disc pl-5">
+                  {feature.bullets.map((item) => (
+                    <li>{item}</li>
+                  ))}
+                </ul>
+              )
+            }
+          </Feature>
+        </Col>
+      ))
+    }
+  </Row>
+</Section>
+

--- a/src/config/footerNavigation.ts
+++ b/src/config/footerNavigation.ts
@@ -106,6 +106,6 @@ export const footerNavigationData: FooterData = {
 		}
 	],
     subFooter: {
-        copywriteText: '© AI Hair Extension 2024.'
+        copywriteText: '© Maugli.cfd 2025 Внедряем ИИ в любые бизнес процессы'
     }
 }

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -10,6 +10,7 @@ import FAQBasic from '../components/blocks/FAQ/Basic.astro'
 import TextImage from '../components/blocks/basic/TextImage.astro'
 import Testimonial from '../components/blocks/testimonials/BasicDark.astro'
 import Feature from '../components/blocks/features/FeatureList.astro'
+import WhiteLabelIncludes from '../components/blocks/features/WhiteLabelIncludes.astro'
 import Section from '../components/ui/Section.astro'
 import Row from '../components/ui/Row.astro'
 import Col from '../components/ui/Col.astro'
@@ -64,6 +65,17 @@ const testimonialData = {
     />
     <Feature />
     <FAQBasic classes="bg-slate-50 dark:bg-neutral-900/40" />
+    <Section>
+      <Row>
+        <Col span="2" />
+        <Col span="8" align="center">
+          <h2 class="text-pretty">AI Hair Extension — бот для пользователей, под которым скрыта бизнес-платформа.</h2>
+          <p class="text-lg">Для клиентов это вау-инструмент примерки, для мастеров — инструмент продаж. Для бизнеса это многофункциональная платформа с огромным потенциалом:</p>
+        </Col>
+        <Col span="2" />
+      </Row>
+    </Section>
+    <WhiteLabelIncludes />
     <Section classes="bg-neutral-50 dark:bg-neutral-900/40">
       <Row>
         <Col span="3" />
@@ -73,7 +85,7 @@ const testimonialData = {
         <Col span="3" />
       </Row>
     </Section>
-</Layout>
+  </Layout>
 
 <style is:global>
   #wl-text .text-image__picture img {


### PR DESCRIPTION
## Summary
- update footer copyright to Maugli.cfd 2025 tagline
- improve mobile layout for chip notification on white label page
- add white-label features section with descriptive cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb67334aec832a927b3587e080f7ff