### PR TITLE
feat: refine pricing page messaging

### DIFF
--- a/src/components/blocks/basic/TextImage.astro
+++ b/src/components/blocks/basic/TextImage.astro
@@ -59,11 +59,11 @@ const {
 		</Col>
 		<Col span="6" classes={`self-center ${imagePosition === 'right' ? 'lg:-order-1' : ''}`}>
 			<div class="text-image__content">
-				<h2 class="text-image__heading" set:html={title} />
-				<p class="text-image__text">{text}</p>
-			</div>
-		</Col>
-	</Row>
+                                <h2 class="text-image__heading" set:html={title} />
+                                <div class="text-image__text" set:html={text} />
+                        </div>
+                </Col>
+        </Row>
 </Section>
 
 <style>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -49,33 +49,28 @@ const testimonialData = {
 		</div>
 	</Section>
 	<Feature />
-	<TextImage
-		title="Why AI Hair Extension Selling Platform’s Pricing Plans Offer Great Value"
-		text="At AI Hair Extension Selling Platform, we believe in providing exceptional value at every price point. Our pricing plans are designed to cater to a variety of needs, from individuals and small teams to large enterprises. Each plan includes access to our powerful features, seamless integrations, and top-notch customer support. "
-		image={faqImage1}
-		mobileImage={faqImage1}
-		imagePosition="left"
-		offsetImage
-		classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"
-	/>
-	<Testimonial
-		blockquote={testimonialData.blockquote}
-		figcaption={testimonialData.figcaption}
-		cite={testimonialData.cite}
-	/>
-	<FaqSticky
-		title="Understanding Our Pricing Plans"
-		text="Get all the details on AI Hair Extension Selling Platform’s pricing plans. Learn about the costs, discounts, and subscription options to find the best plan that fits your needs and budget."
-		data={faqPricing}
-		classes="bg-slate-50 dark:bg-neutral-900/40"
-	/>
-	<FAQBasic classes="bg-slate-50 dark:bg-neutral-900/40" />
-	<Section>
-		<Row>
+        <TextImage
+                title="Платформа — это бот для мастеров, закрывающий все их потребности"
+                text={`<p>Мини-апп — это не только подписка и токены. Это полноценный каталог и рабочая среда мастера:</p>
+<ul class="mt-4 list-disc space-y-2 pl-4">
+        <li>продажи обучения, волос, расходников и косметики прямо в приложении,</li>
+        <li>партнёрские ссылки или твои собственные продукты,</li>
+        <li>каталог мастеров и услуг, интеграции с курсами и поставщиками,</li>
+        <li>удобный маркетплейс внутри привычного интерфейса.</li>
+</ul>
+<p class="mt-4">По сути, бот становится не просто генератором превью, а точкой входа во всё сообщество: от продажи услуг до покупки материалов.</p>`}
+                image={faqImage1}
+                mobileImage={faqImage1}
+                imagePosition="left"
+                offsetImage
+                classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"
+        />
+        <Section>
+                <Row>
                         <Col span="2" />
                         <Col span="8" align="center">
                                 <h2 class="text-pretty">
-                                        AI Hair Extension — бот для пользователей, под которым скрыта <strong>бизнес-платформа</strong>.
+                                        AI Hair Extension — бот для пользователей, под которым скрыта <strong>бизнес-платформа</strong>
                                 </h2>
                                 <p class="text-lg">
                                         Для мастеров — это инструмент продажи услуг с вау-эффектом, для бизнеса — платформа, где можно продавать мастерам не только генерации, но и всё, что нужно для работы — от волос и кератина до обучающих курсов.
@@ -83,12 +78,24 @@ const testimonialData = {
                         </Col>
                         <Col span="2" />
                 </Row>
-	</Section>
-	<WhiteLabelIncludes />
-	<FormHero
-		id="contact"
-		title="Get Answers to Your <strong>Questions</strong>."
-		text="Whether you have a question, need support, or just want to share your feedback, we're all ears. Reach out to us and we'll get back to you as soon as possible."
-		classes="bg-neutral-50 dark:bg-neutral-900/40"
-	/>
+        </Section>
+        <Testimonial
+                blockquote={testimonialData.blockquote}
+                figcaption={testimonialData.figcaption}
+                cite={testimonialData.cite}
+        />
+        <FaqSticky
+                title="Understanding Our Pricing Plans"
+                text="Get all the details on AI Hair Extension Selling Platform’s pricing plans. Learn about the costs, discounts, and subscription options to find the best plan that fits your needs and budget."
+                data={faqPricing}
+                classes="bg-slate-50 dark:bg-neutral-900/40"
+        />
+        <FAQBasic classes="bg-slate-50 dark:bg-neutral-900/40" />
+        <WhiteLabelIncludes />
+        <FormHero
+                id="contact"
+                title="Get Answers to Your <strong>Questions</strong>."
+                text="Whether you have a question, need support, or just want to share your feedback, we're all ears. Reach out to us and we'll get back to you as soon as possible."
+                classes="bg-neutral-50 dark:bg-neutral-900/40"
+        />
 </Layout>


### PR DESCRIPTION
## Summary
- revise pricing page text-image section with new platform copy
- move platform overview under second image and drop trailing period
- allow HTML content in TextImage component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bba8ff6b18832aabbce70b76ba7747