### PR TITLE
Rework community page layout

### DIFF
--- a/src/components/blocks/basic/TextImage.astro
+++ b/src/components/blocks/basic/TextImage.astro
@@ -13,6 +13,8 @@
 // - text: The text of the section
 // - classes: Additional classes to be added to the section
 // - offsetImage: Determines if the image should be offset (positioned absolutely)
+// - pictureClasses: Extra classes for the picture wrapper
+// - imageClasses: Extra classes for the image element
 
 // Components
 // - Layout
@@ -22,61 +24,66 @@ import Col from '../../ui/Col.astro'
 
 // Props
 type Props = {
-	id?: string
-	title?: string
-	image?: any
-	imageWidth?: number
-	imageHeight?: number
-	mobileImage?: any
-	imagePosition?: 'left' | 'right'
-	text?: string
-	classes?: string
-	offsetImage?: boolean
+  id?: string
+  title?: string
+  image?: any
+  imageWidth?: number
+  imageHeight?: number
+  mobileImage?: any
+  imagePosition?: 'left' | 'right'
+  text?: string
+  classes?: string
+  offsetImage?: boolean
+  pictureClasses?: string
+  imageClasses?: string
 }
 const {
-	id,
-	title ,
-	image ,
-	imageWidth,
-	imageHeight,
-	mobileImage,
-	imagePosition = 'right',
-	text ,
-	classes ,
-	offsetImage = false
+  id,
+  title,
+  image,
+  imageWidth,
+  imageHeight,
+  mobileImage,
+  imagePosition = 'right',
+  text,
+  classes,
+  offsetImage = false,
+  pictureClasses = '',
+  imageClasses = ''
 } = Astro.props
 ---
 
 <Section id={id} classes={classes}>
-	<Row>
-		<Col span="6" classes="relative">
-			<picture
-				class=`text-image__picture ${offsetImage  ? 'text-image__picture--offset' : ''} ${imagePosition === 'right' ? 'text-image__picture--offset-right' : ''}`
-			>
-				{mobileImage && <source srcset={mobileImage.src} media="(max-width: 1024px)" />}
-				<img src={image.src} alt={title} width={imageWidth} height={imageHeight} />
-			</picture>
-		</Col>
-		<Col span="6" classes={`self-center ${imagePosition === 'right' ? 'lg:-order-1' : ''}`}>
-			<div class="text-image__content">
-                                <h2 class="text-image__heading" set:html={title} />
-                                <div class="text-image__text" set:html={text} />
-                        </div>
-                </Col>
-        </Row>
+  <Row>
+    <Col span="6" classes="relative">
+      <picture
+        class={`text-image__picture ${offsetImage ? 'text-image__picture--offset' : ''} ${imagePosition=== 'right' ? 'text-image__picture--offset-right' : ''} ${pictureClasses}`}
+      >
+        {mobileImage && <source srcset={mobileImage.src} media="(max-width: 1024px)" />}
+        <img src={image.src} alt={title} width={imageWidth} height={imageHeight} class={imageClasses} />
+      </picture>
+    </Col>
+    <Col span="6" classes={`self-center ${imagePosition === 'right' ? 'lg:-order-1' : ''}`}>
+      <div class="text-image__content">
+        <h2 class="text-image__heading" set:html={title} />
+        <div class="text-image__text" set:html={text} />
+      </div>
+    </Col>
+  </Row>
 </Section>
 
 <style>
-	.text-image__picture {
-		@apply flex justify-center lg:[&.text-image\_\_picture--offset-right_img]:left-0 lg:[&.text-image\_\_picture--offset-right_img]:right-auto lg:[&.text-image\_\_picture--offset]:h-full lg:[&.text-image\_\_picture--offset_img]:absolute lg:[&.text-image\_\_picture--offset_img]:right-0 lg:[&.text-image\_\_picture--offset_img]:top-1/2 lg:[&.text-image\_\_picture--offset_img]:max-w-none lg:[&.text-image\_\_picture--offset_img]:-translate-y-1/2;
-	}
-	.text-image__content {
-		@apply max-w-xl;
-	}
-	.text-image__heading {
-		@apply text-pretty text-2xl lg:text-3xl;
-	}
-	.text-image__text {
-		@apply text-lg leading-relaxed;
-	}
+  .text-image__picture {
+    @apply flex justify-center lg:[&.text-image__picture--offset-right_img]:left-0 lg:[&.text-image__picture--offset-right_img]:right-auto lg:[&.text-image__picture--offset]:h-full lg:[&.text-image__picture--offset_img]:absolute lg:[&.text-image__picture--offset_img]:right-0 lg:[&.text-image__picture--offset_img]:top-1/2 lg:[&.text-image__picture--offset_img]:max-w-none lg:[&.text-image__picture--offset_img]:-translate-y-1/2;
+  }
+  .text-image__content {
+    @apply max-w-xl;
+  }
+  .text-image__heading {
+    @apply text-pretty text-2xl lg:text-3xl;
+  }
+  .text-image__text {
+    @apply text-lg leading-relaxed;
+  }
 </style>
+

--- a/src/pages/create-community.astro
+++ b/src/pages/create-community.astro
@@ -1,13 +1,99 @@
 ---
+// Components
+// - Layout
 import Layout from '../layouts/Layout.astro'
+// - UI Blocks
+import Feature from '../components/blocks/features/FeatureList.astro'
+import TextImage from '../components/blocks/basic/TextImage.astro'
+import Section from '../components/ui/Section.astro'
+import Row from '../components/ui/Row.astro'
+import Col from '../components/ui/Col.astro'
+import Testimonial from '../components/blocks/testimonials/BasicDark.astro'
+import FaqSticky from '../components/blocks/FAQ/FaqSticky.astro'
+import WhiteLabelIncludes from '../components/blocks/features/WhiteLabelIncludes.astro'
+import FormHero from '../components/blocks/hero/ContactHero.astro'
+import CommunityIntro from '../components/blocks/community/CommunityIntro.astro'
+import CommunityCards from '../components/blocks/community/CommunityCards.astro'
+
+// Data
+import faqData from '../data/json-files/faqData.json'
+const faqPricing = faqData.filter((faq) => faq.category === 'pricing')
+
+// Images
+const easyClientImage = { src: '/easy_client.png' }
+const clubImage = { src: '/club.png' }
+
+// SEO
 const SEO = {
   title: 'White Label Платформа',
   description: 'Страница White Label платформы.'
 }
+
+const testimonialData = {
+  blockquote:
+    'Забери рынок до того, как это сделают другие: <strong class="text-primary-500">первая White Label платформа</strong> для наращивания может стать твоим личным золотым рудником.',
+  figcaption: '',
+  cite: ''
+}
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
-  <section class="py-32">
-    <h1 class="text-center text-3xl">White Label Платформа</h1>
-  </section>
+  <Section id="wl-image" padding="none" classes="bg-neutral-50 dark:bg-neutral-900 pt-12">
+    <div class="relative aspect-[1403/726] w-full">
+      <img src={easyClientImage.src} alt="" class="absolute bottom-0 left-0 w-full object-cover" />
+    </div>
+  </Section>
+  <Feature />
+  <TextImage
+    title="Платформа — это бот для мастеров, закрывающий все их потребности"
+    text={`<p>Мини-апп — это не только подписка и токены. Это полноценный каталог и рабочая среда мастера:</p>
+<ul class=\"mt-4 list-disc space-y-2 pl-4\">
+  <li>продажи обучения, волос, расходников и косметики прямо в приложении,</li>
+  <li>партнёрские ссылки или твои собственные продукты,</li>
+  <li>каталог мастеров и услуг, интеграции с курсами и поставщиками,</li>
+  <li>удобный маркетплейс внутри привычного интерфейса.</li>
+</ul>
+<p class=\"mt-4\">По сути, бот становится не просто генератором превью, а точкой входа во всё сообщество: от продажи услуг до покупки материалов.</p>`}
+    image={clubImage}
+    mobileImage={clubImage}
+    imagePosition="left"
+    pictureClasses="items-end"
+    imageClasses="w-full h-full object-contain"
+    classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"
+  />
+  <Section>
+    <Row>
+      <Col span="2" />
+      <Col span="8" align="center">
+        <h2 class="text-pretty">
+          AI Hair Extension — бот для пользователей, под которым скрыта <strong>бизнес-платформа</strong>
+        </h2>
+        <p class="text-lg">
+          Для мастеров — это инструмент продажи услуг с вау-эффектом, для бизнеса — платформа, где можно продавать мастерам не только генерации, но и всё, что нужно для работы — от волос и кератина до обучающих курсов.
+        </p>
+      </Col>
+      <Col span="2" />
+    </Row>
+  </Section>
+  <CommunityIntro />
+  <CommunityCards />
+  <Testimonial
+    blockquote={testimonialData.blockquote}
+    figcaption={testimonialData.figcaption}
+    cite={testimonialData.cite}
+  />
+  <FaqSticky
+    title="Understanding Our Pricing Plans"
+    text="Get all the details on AI Hair Extension Selling Platform’s pricing plans. Learn about the costs, discounts, and subscription options to find the best plan that fits your needs and budget."
+    data={faqPricing}
+    classes="bg-slate-50 dark:bg-neutral-900/40"
+  />
+  <WhiteLabelIncludes />
+  <FormHero
+    id="contact"
+    title="Get Answers to Your <strong>Questions</strong>."
+    text="Whether you have a question, need support, or just want to share your feedback, we're all ears. Reach out to us and we'll get back to you as soon as possible."
+    classes="bg-neutral-50 dark:bg-neutral-900/40"
+  />
 </Layout>
+


### PR DESCRIPTION
## Summary
- Replace computer artwork with club graphic and ensure it stays fully visible
- Introduce customizable picture and image classes for TextImage block
- Rearrange community section and drop redundant FAQ block

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbb46f7a74832aa3a92b028ae1d117