### PR TITLE
refactor: switch testimonial block to light mode

### DIFF
--- a/src/components/blocks/testimonials/BasicDark.astro
+++ b/src/components/blocks/testimonials/BasicDark.astro
@@ -18,7 +18,7 @@ type Props = {
 	cite?: string
 	bg?: any
 	bgPosition?: 'left' | 'right' | 'center'
-    classes?: string
+	classes?: string
 }
 const {
 	blockquote = 'AI Hair Extension Selling Platform is like a rocket boost for our productivity! Its sleek design and out-of-this-world features make managing projects and team communication a breeze.',
@@ -26,36 +26,42 @@ const {
 	cite = 'CEO, Facebook',
 	bg,
 	bgPosition = 'center',
-    classes
+	classes
 } = Astro.props
 ---
 
 <Section
-    id="testimonial"
-    mode="dark"
-    bg={bg}
-    bgPosition={bgPosition}
-    classes={`${classes ? classes + ' ' : ''}dark:border-t border-y border-neutral-800`}
+	id="testimonial"
+	mode="light"
+	bg={bg}
+	bgPosition={bgPosition}
+	classes={`${classes ? classes + ' ' : ''}border-y border-neutral-200`}
 >
 	<Row>
 		<Col span="12">
-            <Testimonial
-                blockquote={blockquote}
-                figcaption={figcaption}
-                cite={cite}
-                align="center"
-                size="4xl"
-                mobileSize="2xl"
-                classes="!leading-tight font-bold xl:text-5xl max-w-4xl mx-auto text-white"
-                quoteSize={112}
-            />
-        </Col>
-    </Row>
+			<Testimonial
+				blockquote={blockquote}
+				figcaption={figcaption}
+				cite={cite}
+				align="center"
+				size="4xl"
+				mobileSize="2xl"
+				classes="!leading-tight font-bold xl:text-5xl max-w-4xl mx-auto text-neutral-900"
+				quoteSize={112}
+			/>
+		</Col>
+	</Row>
 </Section>
 
 <style is:global>
-  /* Make opening quote subtler and text white on colored backgrounds */
-  #testimonial .testimonial--quote { @apply text-white/30; }
-  #testimonial .testimonial__blockquote > p { color: #fff !important; }
-  #testimonial .testimonial__figcaption { color: #fff !important; }
+	/* Make opening quote subtler and text dark on light backgrounds */
+	#testimonial .testimonial--quote {
+		@apply text-neutral-300;
+	}
+	#testimonial .testimonial__blockquote > p {
+		color: #000 !important;
+	}
+	#testimonial .testimonial__figcaption {
+		color: #000 !important;
+	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,27 +14,27 @@ import CTA from '../components/blocks/CTA/BasicLight.astro'
 import testimonialBackground from '../assets/testimonial-bg-01.webp'
 // - SEO
 const SEO = {
-        title: 'AI Hair Extension Selling Platform',
-        description: 'Первая платформа, разработанная специально для продажи услуги наращивания волос и сопутствующих материалов.'
+	title: 'AI Hair Extension Selling Platform',
+	description:
+		'Первая платформа, разработанная специально для продажи услуги наращивания волос и сопутствующих материалов.'
 }
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
 	<Hero />
 	<FeatureRow />
-    <Testimonial 
-      classes="bg-primary-800"
-      blockquote="Волосы — это оружие женщины. Они меняют не только образ, но и возраст в глазах окружающих."
-      figcaption=""
-      cite=""
-    />
-    <FAQ classes="bg-slate-50 dark:bg-neutral-900/40" />
-    <CTA 
-      sectionClasses="bg-neutral-100 dark:bg-neutral-900/40"
-      ctaClasses="!shadow-none"
-      title="Готова к трансформации?"
-      text="Осторожно! После примерки может возникнуть острое желание записаться к мастеру — мы предупредили."
-      buttonLabel="Попробовать бесплатно"
-      buttonLink="https://t.me/hair_extention_bot?utm_source=landing&utm_medium=cta&utm_campaign=ai_hair_extension"
-    />
+	<Testimonial
+		blockquote="Волосы — это оружие женщины. Они меняют не только образ, но и возраст в глазах окружающих."
+		figcaption=""
+		cite=""
+	/>
+	<FAQ classes="bg-slate-50 dark:bg-neutral-900/40" />
+	<CTA
+		sectionClasses="bg-neutral-100 dark:bg-neutral-900/40"
+		ctaClasses="!shadow-none"
+		title="Готова к трансформации?"
+		text="Осторожно! После примерки может возникнуть острое желание записаться к мастеру — мы предупредили."
+		buttonLabel="Попробовать бесплатно"
+		buttonLink="https://t.me/hair_extention_bot?utm_source=landing&utm_medium=cta&utm_campaign=ai_hair_extension"
+	/>
 </Layout>


### PR DESCRIPTION
## Summary
- update testimonials block to use light mode styling
- remove dark class usage from homepage testimonial

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe0eb3204832ab60da3886f4d04f2