### PR TITLE
feat: reduce pricing page section padding

### DIFF
--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -85,7 +85,7 @@ const testimonialData = {
                 imagePosition="left"
                 offsetImage
                 imageClasses="w-full max-h-[600px] object-contain"
-                classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-64"
+                classes="bg-neutral-50 dark:bg-neutral-900 lg:!py-32"
         />
 	<FaqSticky
 		title="Understanding Our Pricing Plans"


### PR DESCRIPTION
## Summary
- adjust TextImage section on pricing page to use `lg:!py-32` for half the previous padding on large screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe3d3df34832a83f9a13a334b5722