### PR TITLE
feat: expand contact hero with purchase details

### DIFF
--- a/src/components/blocks/contact/BasicForm.astro
+++ b/src/components/blocks/contact/BasicForm.astro
@@ -26,10 +26,8 @@ const { classes } = Astro.props
 <Card classes={classes}>
 	<CardBody>
 		<Form>
-			<h2 class="text-2xl">Для покупки платформы</h2>
 			<FormField>
 				<InputField type="text" id="firstName" label="Имя" />
-	
 			</FormField>
 			<FormField>
 				<InputField type="email" id="email" label="Почта" required value="name@youremail.com" />
@@ -38,7 +36,19 @@ const { classes } = Astro.props
 				<InputField type="tel" id="phone" label="WhatsApp" />
 				<InputField type="text" id="tg" label=" Имя в Телеграм" />
 			</FormField>
-			<FormField><TextArea id="message" label="Напишите, в каком из мессенджеров с вами удобнее связаться" /></FormField>
+			<FormField
+				><TextArea
+					id="message"
+					label="Напишите, в каком из мессенджеров с вами удобнее связаться"
+				/></FormField
+			>
+			<p class="mt-4 text-xs text-neutral-500">
+				Отправляя форму вы соглашаетесь с
+				<a href="/privacy" class="underline" target="_blank" rel="noopener noreferrer"
+					>политикой конфиденциальности</a
+				>
+				сайта.
+			</p>
 			<Button style="primary" type="submit">Заказать демонстрацию</Button>
 		</Form>
 	</CardBody>

--- a/src/components/blocks/hero/ContactHero.astro
+++ b/src/components/blocks/hero/ContactHero.astro
@@ -18,19 +18,47 @@ type Props = {
 	text?: string
 	classes?: string
 }
-const { id, title, text, classes } = Astro.props
+const { id, classes } = Astro.props
 ---
 
 <Section id={id} classes={classes}>
 	<Row>
 		<Col span="6" classes={`self-center`}>
 			<header class="max-w-xl">
-				<h1 set:html={title} />
-				<p class="text-lg leading-relaxed">{text}</p>
+				<h1>Платформа доступна к покупке</h1>
+				<p class="text-lg leading-relaxed">
+					Вы можете приобрести платформу или получить подробную консультацию. Свяжитесь с нами в
+					мессенджерах ниже или заполните форму.
+				</p>
+				<ul class="mt-6 space-y-2">
+					<li>
+						<a
+							href="https://t.me/darrrina"
+							class="text-primary-500 underline-offset-2 hover:underline"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Telegram
+						</a>
+					</li>
+					<li>
+						<a
+							href="https://wa.me/18492584643"
+							class="text-primary-500 underline-offset-2 hover:underline"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							WhatsApp
+						</a>
+					</li>
+				</ul>
 			</header>
 		</Col>
 		<Col span="6" classes="relative">
 			<Form classes="max-w-xl" />
+			<p class="mt-4 text-sm text-neutral-500">
+				Мы свяжемся с вами, расскажем об условиях и подготовим персональное предложение.
+			</p>
 		</Col>
 	</Row>
 </Section>


### PR DESCRIPTION
## Summary
- add purchase copy with Telegram and WhatsApp links to contact hero
- append privacy policy notice and remove built-in heading from basic form

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe6f7e5a0832ab132c3f5abef4d7e