### PR TITLE
Add privacy policy page and links

### DIFF
--- a/src/components/blocks/contact/BasicForm.astro
+++ b/src/components/blocks/contact/BasicForm.astro
@@ -42,13 +42,11 @@ const { classes } = Astro.props
 					label="Напишите, в каком из мессенджеров с вами удобнее связаться"
 				/></FormField
 			>
-			<p class="mt-4 text-xs text-neutral-500">
-				Отправляя форму вы соглашаетесь с
-				<a href="/privacy" class="underline" target="_blank" rel="noopener noreferrer"
-					>политикой конфиденциальности</a
-				>
-				сайта.
-			</p>
+                        <p class="mt-4 text-xs text-neutral-500">
+                                Отправляя форму вы соглашаетесь с
+                                <a href="/privacy" class="underline">Политика конфиденциальности</a>
+                                сайта.
+                        </p>
 			<Button style="primary" type="submit">Заказать демонстрацию</Button>
 		</Form>
 	</CardBody>

--- a/src/config/footerNavigation.ts
+++ b/src/config/footerNavigation.ts
@@ -60,16 +60,20 @@ export const footerNavigationData: FooterData = {
 					subCategory: 'Pricing',
 					subCategoryLink: '/pricing'
 				},
-				{
-					subCategory: 'Changelog',
-					subCategoryLink: '/changelog'
-				},
-				{
-					subCategory: 'Terms',
-					subCategoryLink: '/terms'
-				}
-			]
-		},
+                                {
+                                        subCategory: 'Changelog',
+                                        subCategoryLink: '/changelog'
+                                },
+                                {
+                                        subCategory: 'Terms',
+                                        subCategoryLink: '/terms'
+                                },
+                                {
+                                        subCategory: 'Политика конфиденциальности',
+                                        subCategoryLink: '/privacy'
+                                }
+                        ]
+                },
 		{
 			category: 'About us',
 			subCategories: [

--- a/src/config/navigationBar.ts
+++ b/src/config/navigationBar.ts
@@ -48,7 +48,8 @@ export const navigationBarData: NavData = {
                 { name: 'Блог', link: '/blog' },
                 { name: 'История изменений', link: '/changelog' },
                 { name: 'FAQ', link: '/faq' },
-                { name: 'Условия', link: '/terms' }
+                { name: 'Условия', link: '/terms' },
+                { name: 'Политика конфиденциальности', link: '/privacy' }
             ]
         },
         { name: 'Контакты', link: '/pricing#contact' }

--- a/src/data/markdown-files/privacy.md
+++ b/src/data/markdown-files/privacy.md
@@ -1,0 +1,48 @@
+# Privacy Policy
+
+## Introduction
+
+Welcome to AI Hair Extension Selling Platform. This Privacy Policy explains how we collect, use, and safeguard your personal information when you interact with our services.
+
+## Information We Collect
+
+We may collect the following types of information when you use our platform:
+
+- **Personal Information:** such as your name, email address, phone number, and payment details when you create an account or make a purchase.
+- **Usage Data:** information on how you access and use the service, including your IP address, browser type, and pages visited.
+- **Communications:** any messages or inquiries you send to us through our contact forms or support channels.
+
+## How We Use Your Information
+
+We use the collected information to:
+
+- Provide, operate, and maintain our services
+- Communicate with you about your account or transactions
+- Improve, personalize, and expand our platform
+- Send you updates, marketing, and promotional materials, if you have opted in
+- Comply with legal obligations and protect our rights
+
+## Data Sharing and Disclosure
+
+We do not sell your personal information. We may share your data with trusted third parties who assist us in operating our services, such as payment processors and hosting providers, under strict confidentiality agreements. We may also disclose information when required by law or to protect our rights.
+
+## Data Security
+
+We implement reasonable security measures to protect your personal information from unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the Internet or electronic storage is completely secure, so we cannot guarantee absolute security.
+
+## Your Rights and Choices
+
+You have the right to access, update, or delete your personal information. You may also object to or restrict certain processing activities. To exercise these rights, please contact us using the information provided below.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated "Last updated" date. We encourage you to review this policy periodically.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy or our data practices, please contact us at:
+
+Email: support@AIHairExtensionSellingPlatform.com
+Address: 123 AI Hair Extension Selling Platform Lane, Productivity City, PC 12345
+
+_Last updated: July 10, 2024_

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,35 @@
+---
+// Components
+import Layout from '../layouts/Layout.astro'
+import SidebarContent from '../components/blocks/basic/StickySidebar.astro'
+import Hero from '../components/blocks/hero/PageHeader.astro'
+import PrivacyContent from '../data/markdown-files/privacy.md'
+
+// Content
+// - SEO
+const SEO = {
+        title: 'AI Hair Extension Selling Platform | Privacy Policy',
+        description:
+                "Learn how AI Hair Extension Selling Platform collects, uses, and protects your personal information."
+}
+// - Page Header
+const header = {
+        title: 'Privacy Policy: Your Data, <strong>Protected!</strong>',
+        text: 'Understand how we handle your information.'
+}
+---
+
+<Layout title={SEO.title} description={SEO.description}>
+        <Hero title={header.title} text={header.text} />
+        <SidebarContent>
+                <div slot="sidebar">
+                        <h3>Overview</h3>
+                        <p>
+                                Read about our commitment to protecting your personal data.
+                        </p>
+                </div>
+                <div class="basic-text">
+                        <PrivacyContent />
+                </div>
+        </SidebarContent>
+</Layout>


### PR DESCRIPTION
## Summary
- Introduce `privacy.md` with platform privacy details
- Add `/privacy` page and link it in navigation and footer
- Update contact form to reference the privacy policy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bbea54c208832a9f5ddb7989257271