### PR TITLE
chore: apply brand color

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "AI Hair Extension",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#134e4a",
+  "background_color": "#AC9468",
+  "theme_color": "#AC9468",
   "icons": [
     {
       "src": "/hair_extension_192.webp",

--- a/src/components/blocks/head/Header.astro
+++ b/src/components/blocks/head/Header.astro
@@ -46,7 +46,7 @@ const {
 	<link rel="icon" href={configData.logo.src} type="image/svg+xml" />
         <link rel="sitemap" href="/sitemap-index.xml" />
         <meta name="generator" content={Astro.generator} />
-        <meta name="theme-color" content="#134e4a" />
+        <meta name="theme-color" content="#AC9468" />
         <link rel="manifest" href="/site.webmanifest" />
         <!-- Geologica font for headings -->
 	<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,7 @@ html {
 	@apply scroll-smooth antialiased;
 }
 body {
-	@apply font-sans bg-white text-neutral-500 has-[.header\_\_menu--open]:overflow-hidden lg:has-[.header\_\_menu--open]:overflow-auto dark:bg-neutral-950 dark:text-neutral-400 [.dark_&]:text-neutral-400 [.light_&]:text-neutral-500;
+        @apply font-sans bg-primary-50 text-neutral-500 has-[.header\_\_menu--open]:overflow-hidden lg:has-[.header\_\_menu--open]:overflow-auto dark:bg-neutral-950 dark:text-neutral-400 [.dark_&]:text-neutral-400 [.light_&]:text-neutral-500;
 }
 
 /* Main typography */


### PR DESCRIPTION
## Summary
- update web manifest to reflect brand color
- use brand theme color in head meta
- set light mode background to brand tint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbeb684758832abfb1758bced99000