### PR TITLE
feat: update platform connection timeline and colors

### DIFF
--- a/src/data/json-files/changelogData.json
+++ b/src/data/json-files/changelogData.json
@@ -1,36 +1,20 @@
 [
-	{
-		"title": "v1.0.6: Enhanced Security Features",
-		"date": "2024-07-01",
-		"text": "<p>We've implemented new security protocols to safeguard your data. Enjoy peace of mind with improved encryption and multi-factor authentication.</p> <ul><li>2FA enabled by default</li><li>HubSpot integration</li><li>Zoho CRM integration</li></ul>",
-		"image": "/feeds/feed-01.png"
-	},
-	{
-		"title": "v1.0.5: User Interface Improvements",
-		"date": "2024-06-15",
-		"text": "<p>Our latest update brings a revamped user interface for a more intuitive and visually appealing experience. Navigation and usability have been greatly enhanced.</p><ul><li>Updated dashboard layout</li><li>Improved accessibility features</li><li>Streamlined navigation menus</li></ul>",
-		"image": "/feeds/feed-02.png"
-	},
-	{
-		"title": "v1.0.4: New In-App Messaging",
-		"date": "2024-05-20",
-		"text": "<p>Introducing in-app messaging! Communicate directly within the app to keep conversations organized and accessible without switching between tools.</p>"
-	},
-	{
-		"title": "v1.0.3: Performance Enhancements",
-		"date": "2024-04-10",
-		"text": "<p>We've optimized the app to run faster and smoother. Experience improved load times and overall performance.</p>",
-		"image": "/feeds/feed-03.png"
-	},
-	{
-		"title": "v1.0.2: CRM Integration",
-		"date": "2024-03-25",
-		"text": "<p>Connect your app with popular CRM systems to streamline customer management. Synchronize data and improve customer relationship processes.</p><ul><li>Salesforce integration</li><li>HubSpot integration</li><li>Zoho CRM integration</li></ul>"
-	},
-	{
-		"title": "v1.0.1: Third-Party API Support",
-		"date": "2024-02-15",
-		"text": "<p>Seamlessly integrate with third-party APIs to extend the functionality of your app. Enjoy smooth data exchange and enhanced performance.</p>",
-		"image": "/feeds/feed-04.png"
-	}
+  {
+    "title": "Для небольших школ",
+    "date": "Simple",
+    "text": "<p>До 20–30 активных пользователей в день.</p><p>Включает:</p><ul><li>Бота</li><li>Адаптацию материалов под бренд</li><li>Mini-app для пополнения баланса</li><li>Обучение по платформе</li></ul><p>Включено 40 000 токенов в месяц.</p><p>+30% от стоимости токенов сверх пакета</p>",
+    "image": "/feeds/feed-01.png"
+  },
+  {
+    "title": "Для средних школ/салонов",
+    "date": "Full",
+    "text": "<p>30–100 пользователей в день.</p><p>Дополнительно к Simple:</p><ul><li>Доступ к каталогу прямо из mini-app</li><li>Возможность добавлять собственные и партнёрские услуги</li><li>Возможность менять стоимость пакетов</li></ul><p>Включено 80 000 токенов в месяц.</p><p>+30% от стоимости токенов сверх пакета</p>",
+    "image": "/feeds/feed-02.png"
+  },
+  {
+    "title": "Территориальный — город",
+    "date": "Exclusive",
+    "text": "<p>100+ пользователей в день.</p><p>Всё, что в Full, плюс эксклюзивное право на город.</p><p>Включено 200 000 токенов в месяц.</p><p>+30% от стоимости токенов сверх пакета</p>",
+    "image": "/feeds/feed-03.png"
+  }
 ]

--- a/src/data/json-files/pricingTablesdata.json
+++ b/src/data/json-files/pricingTablesdata.json
@@ -1,78 +1,65 @@
 [
-	{
-		"header": {
-			"title": "Basic",
-			"subtitle": "Ideal for individual developers.",
-			"currency": "$",
-			"price": "19",
-			"priceLabel": "month, billed anually",
-			"priceMontly": "25",
-			"priceLabelMontly": "month",
-			"buttonName": "Try for free",
-			"buttonLink": "/"
-		},
-		"body": {
-			"listItems": [
-				{ "listItem": "Join forces with fellow architects" },
-				{ "listItem": "Present your projects with flair and captivate your audience." },
-				{ "listItem": "Immerse yourself in the dynamic realm of architecture." }
-			]
-		},
-		"footer": {
-			"buttonName": "See all features",
-			"buttonLink": "/"
-		},
-		"type": "basic"
-	},
-	{
-		"header": {
-			"title": "Team",
-			"subtitle": "Ideal for small teams",
-			"currency": "$",
-			"price": "29",
-			"priceLabel": "month, billed anually",
-			"priceMontly": "35",
-			"priceLabelMontly": "month",
-			"buttonName": "Try for free",
-			"buttonLink": "/"
-		},
-		"body": {
-			"listItems": [
-				{ "listItem": "Join forces with fellow architects" },
-				{ "listItem": "Present your projects with flair and captivate your audience." },
-				{ "listItem": "Immerse yourself in the dynamic realm of architecture." },
-				{ "listItem": "Unlock endless inspiration" }
-			]
-		},
-		"footer": {
-			"buttonName": "See all features",
-			"buttonLink": "/"
-		},
-		"type": "featured"
-	},
-	{
-		"header": {
-			"title": "Enterprise",
-			"subtitle": "Ideal for companies",
-			"currency": "$",
-			"price": "49",
-			"priceLabel": "month, billed anually",
-			"priceMontly": "65",
-			"priceLabelMontly": "month",
-			"buttonName": "Try for free",
-			"buttonLink": "/"
-		},
-		"body": {
-			"listItems": [
-				{ "listItem": "Join forces with fellow architects" },
-				{ "listItem": "Present your projects with flair and captivate your audience." },
-				{ "listItem": "Immerse yourself in the dynamic realm of architecture." }
-			]
-		},
-		"footer": {
-			"buttonName": "See all features",
-			"buttonLink": "/"
-		},
-		"type": "basic"
-	}
+  {
+    "header": {
+      "title": "Simple",
+      "subtitle": "для небольших школ",
+      "currency": "",
+      "price": "По запросу",
+      "priceLabel": "",
+      "priceMontly": "По запросу",
+      "priceLabelMontly": "",
+      "buttonName": "Связаться",
+      "buttonLink": "https://t.me/darrrina"
+    },
+    "body": {
+      "listItems": [
+        { "listItem": "До 20–30 активных пользователей в день" },
+        { "listItem": "Включено 40 000 токенов в месяц" },
+        { "listItem": "Бот и адаптация под бренд" }
+      ]
+    },
+    "type": "basic"
+  },
+  {
+    "header": {
+      "title": "Full",
+      "subtitle": "для средних школ/салонов",
+      "currency": "",
+      "price": "По запросу",
+      "priceLabel": "",
+      "priceMontly": "По запросу",
+      "priceLabelMontly": "",
+      "buttonName": "Связаться",
+      "buttonLink": "https://t.me/darrrina"
+    },
+    "body": {
+      "listItems": [
+        { "listItem": "30–100 пользователей в день" },
+        { "listItem": "Все из Simple + каталог и собственные услуги" },
+        { "listItem": "Включено 80 000 токенов в месяц" }
+      ]
+    },
+    "type": "featured"
+  },
+  {
+    "header": {
+      "title": "Exclusive",
+      "subtitle": "территориальный — город",
+      "currency": "",
+      "price": "По запросу",
+      "priceLabel": "",
+      "priceMontly": "По запросу",
+      "priceLabelMontly": "",
+      "buttonName": "Связаться",
+      "buttonLink": "https://t.me/darrrina"
+    },
+    "body": {
+      "listItems": [
+        { "listItem": "100+ пользователей в день" },
+        { "listItem": "Всё из Full + эксклюзивное право на город" },
+        { "listItem": "Включено 200 000 токенов в месяц" }
+      ]
+    },
+    "type": "basic"
+  }
 ]

--- a/src/pages/create-community.astro
+++ b/src/pages/create-community.astro
@@ -13,9 +13,12 @@ import WhiteLabelIncludes from '../components/blocks/features/WhiteLabelIncludes
 import FormHero from '../components/blocks/hero/ContactHero.astro'
 import CommunityIntro from '../components/blocks/community/CommunityIntro.astro'
 import CommunityCards from '../components/blocks/community/CommunityCards.astro'
+import SimpleFeed from '../components/blocks/feeds/BasicFeed.astro'
+import PricingColumns from '../components/blocks/pricing/PricingColumns.astro'
 
 // Data
 import faqData from '../data/json-files/faqData.json'
+import feedData from '../data/json-files/changelogData.json'
 const faqPricing = faqData.filter((faq) => faq.category === 'pricing')
 
 // Images
@@ -80,6 +83,18 @@ const testimonialData = {
     figcaption={testimonialData.figcaption}
     cite={testimonialData.cite}
   />
+  <Section>
+    <Row>
+      <Col span="2" />
+      <Col span="8" align="center">
+        <h2>Подключение к платформе</h2>
+        <p class="text-lg">Выбирайте вариант, который соответствует вашим масштабам и целям.</p>
+      </Col>
+      <Col span="2" />
+    </Row>
+  </Section>
+  <SimpleFeed data={feedData} />
+  <PricingColumns />
   <FaqSticky
     title="Understanding Our Pricing Plans"
     text="Get all the details on AI Hair Extension Selling Platform’s pricing plans. Learn about the costs, discounts, and subscription options to find the best plan that fits your needs and budget."

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,7 @@ html {
 	@apply scroll-smooth antialiased;
 }
 body {
-        @apply font-sans bg-primary-50 text-neutral-500 has-[.header\_\_menu--open]:overflow-hidden lg:has-[.header\_\_menu--open]:overflow-auto dark:bg-neutral-950 dark:text-neutral-400 [.dark_&]:text-neutral-400 [.light_&]:text-neutral-500;
+        @apply font-sans bg-white text-neutral-500 has-[.header\_\_menu--open]:overflow-hidden lg:has-[.header\_\_menu--open]:overflow-auto dark:bg-neutral-950 dark:text-neutral-400 [.dark_&]:text-neutral-400 [.light_&]:text-neutral-500;
 }
 
 /* Main typography */
@@ -76,7 +76,7 @@ main a {
 }
 /* Global basic styling */
 .basic-text {
-	@apply [&_blockquote]:relative [&_blockquote]:mb-6 [&_blockquote]:rounded [&_blockquote]:border [&_blockquote]:border-neutral-100 [&_blockquote]:bg-neutral-50 [&_blockquote]:p-6 [&_blockquote]:text-lg [&_blockquote]:leading-relaxed [&_blockquote]:text-neutral-700 [&_blockquote]:before:absolute [&_blockquote]:before:left-0 [&_blockquote]:before:top-0 [&_blockquote]:before:z-[0] [&_blockquote]:before:block [&_blockquote]:before:text-9xl [&_blockquote]:before:italic [&_blockquote]:before:text-neutral-200 [&_blockquote]:before:opacity-50 [&_blockquote]:before:content-['"'] lg:[&_blockquote]:-mx-12 dark:[&_blockquote]:border-neutral-600 dark:[&_blockquote]:bg-neutral-700 dark:[&_blockquote]:text-neutral-50 dark:[&_blockquote]:before:text-neutral-600 [&_blockquote_p]:relative [&_blockquote_p]:z-[1] [&_blockquote_p]:px-6 [&_h1:not(:first-child)]:mt-24 [&_h2:not(:first-child)]:mt-24 [&_h3:not(:first-child)]:mt-24 [&_h4:not(:first-child)]:mt-12 [&_img]:rounded [&_img]:border [&_img]:border-neutral-100 dark:[&_img]:border-neutral-600 [&_li]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_li]:marker:text-primary-500 lg:[&_p:has(img)]:-mx-12;
+        @apply [&_blockquote]:relative [&_blockquote]:mb-6 [&_blockquote]:rounded [&_blockquote]:border [&_blockquote]:border-[#1A1A1A] [&_blockquote]:bg-[#1A1A1A] [&_blockquote]:p-6 [&_blockquote]:text-lg [&_blockquote]:leading-relaxed [&_blockquote]:text-neutral-50 [&_blockquote]:before:absolute [&_blockquote]:before:left-0 [&_blockquote]:before:top-0 [&_blockquote]:before:z-[0] [&_blockquote]:before:block [&_blockquote]:before:text-9xl [&_blockquote]:before:italic [&_blockquote]:before:text-neutral-600 [&_blockquote]:before:opacity-50 [&_blockquote]:before:content-['"'] lg:[&_blockquote]:-mx-12 dark:[&_blockquote]:border-[#1A1A1A] dark:[&_blockquote]:bg-[#1A1A1A] dark:[&_blockquote]:text-neutral-50 dark:[&_blockquote]:before:text-neutral-600 [&_blockquote_p]:relative [&_blockquote_p]:z-[1] [&_blockquote_p]:px-6 [&_h1:not(:first-child)]:mt-24 [&_h2:not(:first-child)]:mt-24 [&_h3:not(:first-child)]:mt-24 [&_h4:not(:first-child)]:mt-12 [&_img]:rounded [&_img]:border [&_img]:border-neutral-100 dark:[&_img]:border-neutral-600 [&_li]:mb-2 [&_li]:ml-4 [&_li]:list-disc [&_li]:marker:text-primary-500 lg:[&_p:has(img)]:-mx-12;
 }
 .basic-text--lg {
 	@apply text-lg leading-relaxed [&_blockquote]:text-xl [&_blockquote]:leading-loose;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -34,17 +34,17 @@ export default {
       colors: {
         transparent: "transparent",
         primary: {
-          50: "#F6F1E9",
-          100: "#EEE4D6",
-          200: "#E0CFB6",
-          300: "#D2BA96",
-          400: "#C6A97E",
-          500: "#AC9468", // base requested color
-          600: "#927C54",
-          700: "#786643",
-          800: "#5E5032",
-          900: "#4B3F28",
-          950: "#332A1B",
+          50: "#F7F5F0",
+          100: "#EEE8DD",
+          200: "#DECFBA",
+          300: "#CDB697",
+          400: "#BB9E74",
+          500: "#A8874B", // base requested color
+          600: "#8C6F3E",
+          700: "#705832",
+          800: "#554127",
+          900: "#392B1B",
+          950: "#241B11",
         },
         neutral: {
           50: "#f8fafc",


### PR DESCRIPTION
## Summary
- switch site theme to white base with new beige accent
- add platform connection timeline and pricing sections before FAQ
- update timeline and pricing data to use Simple/Full/Exclusive tiers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bca5ab5750832a92218278064ffd33