### PR TITLE
feat: move testimonial background to section

### DIFF
--- a/src/components/blocks/testimonials/BasicDark.astro
+++ b/src/components/blocks/testimonials/BasicDark.astro
@@ -31,11 +31,10 @@ const {
 ---
 
 <Section
-	id="testimonial"
-	mode="light"
-	bg={bg}
-	bgPosition={bgPosition}
-	classes={`${classes ? classes + ' ' : ''}border-y border-neutral-200`}
+        id="testimonial"
+        bg={bg}
+        bgPosition={bgPosition}
+        classes={`${classes ? classes + ' ' : ''}border-y border-neutral-200 bg-[#1A1A1A] text-white`}
 >
 	<Row>
 		<Col span="12">

--- a/src/components/ui/Testimonial.astro
+++ b/src/components/ui/Testimonial.astro
@@ -110,7 +110,11 @@ const {
         .testimonial--quote {
                 @apply absolute left-6 top-6 z-0 text-neutral-50 dark:text-neutral-50/15;
         }
-    
+
+       .testimonial__container {
+               @apply relative w-full overflow-hidden;
+       }
+
         .testimonial__figure {
                 @apply relative z-10;
         }


### PR DESCRIPTION
## Summary
- ensure testimonial container is layout-only without background
- apply full-width dark background and white text to testimonial section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a886fe0832aac0483888507c300